### PR TITLE
add snap_only enable

### DIFF
--- a/library/react-connect-kit/package.json
+++ b/library/react-connect-kit/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@chainsafe/metamask-polkadot-adapter": "^0.6.0",
     "@polkadot/util": "^12.6.2",
-    "@polkagate/extension-dapp": "^0.46.7-22",
+    "@polkagate/extension-dapp": "^0.46.8",
     "@w3ux/extension-assets": "^0.2.3",
     "@w3ux/hooks": "^0.0.3",
     "@w3ux/utils": "^0.0.2"

--- a/library/react-connect-kit/src/ExtensionsProvider/index.tsx
+++ b/library/react-connect-kit/src/ExtensionsProvider/index.tsx
@@ -81,7 +81,7 @@ export const ExtensionsProvider = ({
 
     // Inject PolkaGate Snap if enabled.
     if (polkaGateSnapEnabled) {
-      await withTimeout(500, web3Enable("w3ux"));
+      await withTimeout(500, web3Enable("snap_only"));
     }
 
     if (hasInjectedWeb3 || snapAvailable) {


### PR DESCRIPTION
The changes will let the app to only enable the snap when it calls `web3Enable("snap_only")`.