### PR TITLE
feat: Connect kit improvements

### DIFF
--- a/library/react-connect-kit/package.json
+++ b/library/react-connect-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/react-connect-kit-source",
   "license": "GPL-3.0-only",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/react-connect-kit/package.json
+++ b/library/react-connect-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/react-connect-kit-source",
   "license": "GPL-3.0-only",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/react-connect-kit/src/ExtensionAccountsProvider/Extensions.ts
+++ b/library/react-connect-kit/src/ExtensionAccountsProvider/Extensions.ts
@@ -13,7 +13,7 @@ import {
   ExtensionInterface,
 } from "../ExtensionsProvider/types";
 import Keyring from "@polkadot/keyring";
-import { DEFAULT_SS58_PREFIX } from "./defaults";
+import { DEFAULT_SS58 } from "./defaults";
 
 // A static class to manage the discovery and importing of extensions.
 export class Extensions {
@@ -100,7 +100,7 @@ export class Extensions {
   ): Promise<ExtensionAccount[]> => {
     // By default, format addresses with the default ss58 prefix.
     const keyring = new Keyring();
-    keyring.setSS58Format(DEFAULT_SS58_PREFIX);
+    keyring.setSS58Format(DEFAULT_SS58);
 
     try {
       const results = await Promise.allSettled(

--- a/library/react-connect-kit/src/ExtensionAccountsProvider/Extensions.ts
+++ b/library/react-connect-kit/src/ExtensionAccountsProvider/Extensions.ts
@@ -13,6 +13,7 @@ import {
   ExtensionInterface,
 } from "../ExtensionsProvider/types";
 import Keyring from "@polkadot/keyring";
+import { DEFAULT_SS58_PREFIX } from "./defaults";
 
 // A static class to manage the discovery and importing of extensions.
 export class Extensions {
@@ -95,11 +96,11 @@ export class Extensions {
 
   // Calls `enable` and formats the results of an extension's `enable` function.
   static getAllAccounts = async (
-    extensions: ExtensionEnableResults,
-    ss58: number
+    extensions: ExtensionEnableResults
   ): Promise<ExtensionAccount[]> => {
+    // By default, format addresses with the default ss58 prefix.
     const keyring = new Keyring();
-    keyring.setSS58Format(ss58);
+    keyring.setSS58Format(DEFAULT_SS58_PREFIX);
 
     try {
       const results = await Promise.allSettled(
@@ -118,7 +119,7 @@ export class Extensions {
 
         if (result.status === "fulfilled") {
           const filtered = result.value
-            // Reformat addresses with correct ss58 prefix.
+            // Reformat addresses with default ss58 prefix.
             .map((newAccount) => ({
               ...newAccount,
               address: keyring.addFromAddress(newAccount.address).address,

--- a/library/react-connect-kit/src/ExtensionAccountsProvider/defaults.ts
+++ b/library/react-connect-kit/src/ExtensionAccountsProvider/defaults.ts
@@ -19,4 +19,4 @@ export const defaultHandleImportExtension = {
   },
 };
 
-export const DEFAULT_SS58_PREFIX = 0;
+export const DEFAULT_SS58 = 0;

--- a/library/react-connect-kit/src/ExtensionAccountsProvider/defaults.ts
+++ b/library/react-connect-kit/src/ExtensionAccountsProvider/defaults.ts
@@ -8,7 +8,7 @@ export const defaultExtensionAccountsContext: ExtensionAccountsContextInterface 
   {
     connectExtensionAccounts: () => Promise.resolve(false),
     extensionAccountsSynced: "unsynced",
-    extensionAccounts: [],
+    getExtensionAccounts: (ss58) => [],
   };
 
 export const defaultHandleImportExtension = {
@@ -18,3 +18,5 @@ export const defaultHandleImportExtension = {
     removedActiveAccount: null,
   },
 };
+
+export const DEFAULT_SS58_PREFIX = 0;

--- a/library/react-connect-kit/src/ExtensionAccountsProvider/index.tsx
+++ b/library/react-connect-kit/src/ExtensionAccountsProvider/index.tsx
@@ -307,12 +307,17 @@ export const ExtensionAccountsProvider = ({
 
   // Handle adaptors for extensions that are not supported by `injectedWeb3`.
   const handleExtensionAdapters = async (extensionIds: string[]) => {
-    // Connect to Metamask Polkadot Snap and inject into `injectedWeb3` if avaialble.
-    if (extensionIds.find((id) => id === "metamask-polkadot-snap")) {
-      await initPolkadotSnap({
-        networkName: network as SnapNetworks,
-        addressPrefix: DEFAULT_SS58_PREFIX,
-      });
+    try {
+      // Connect to Metamask Polkadot Snap and inject into `injectedWeb3` if avaialble.
+      if (extensionIds.find((id) => id === "metamask-polkadot-snap")) {
+        await initPolkadotSnap({
+          networkName: network as SnapNetworks,
+          addressPrefix: DEFAULT_SS58_PREFIX,
+        });
+      }
+    } catch (e) {
+      // Provided network is not supported, or something else went wrong with initialisation.
+      // Silently fail.
     }
   };
 

--- a/library/react-connect-kit/src/ExtensionAccountsProvider/index.tsx
+++ b/library/react-connect-kit/src/ExtensionAccountsProvider/index.tsx
@@ -3,10 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { createContext, useContext, useEffect, useRef, useState } from "react";
 import { localStorageOrDefault, setStateWithRef } from "@w3ux/utils";
-import {
-  DEFAULT_SS58_PREFIX,
-  defaultExtensionAccountsContext,
-} from "./defaults";
+import { DEFAULT_SS58, defaultExtensionAccountsContext } from "./defaults";
 import { ImportedAccount, AnyFunction, Sync, VoidFn } from "../types";
 import {
   ExtensionAccount,
@@ -312,7 +309,7 @@ export const ExtensionAccountsProvider = ({
       if (extensionIds.find((id) => id === "metamask-polkadot-snap")) {
         await initPolkadotSnap({
           networkName: network as SnapNetworks,
-          addressPrefix: DEFAULT_SS58_PREFIX,
+          addressPrefix: DEFAULT_SS58,
         });
       }
     } catch (e) {

--- a/library/react-connect-kit/src/ExtensionAccountsProvider/types.ts
+++ b/library/react-connect-kit/src/ExtensionAccountsProvider/types.ts
@@ -8,13 +8,12 @@ import { ImportedAccount, MaybeAddress, Sync } from "../types";
 export interface ExtensionAccountsContextInterface {
   connectExtensionAccounts: (id?: string) => Promise<boolean>;
   extensionAccountsSynced: Sync;
-  extensionAccounts: ImportedAccount[];
+  getExtensionAccounts: (ss58: number) => ImportedAccount[];
 }
 
 export interface ExtensionAccountsProviderProps {
   children: ReactNode;
   network: string;
-  ss58: number;
   dappName: string;
   activeAccount?: MaybeAddress;
   setActiveAccount?: (address: MaybeAddress) => void;
@@ -27,9 +26,4 @@ export interface HandleImportExtension {
     accountsToRemove: ExtensionAccount[];
     removedActiveAccount: MaybeAddress;
   };
-}
-
-export interface NetworkSS58 {
-  network: string;
-  ss58: number;
 }

--- a/library/react-connect-kit/src/ExtensionAccountsProvider/useImportExtension.tsx
+++ b/library/react-connect-kit/src/ExtensionAccountsProvider/useImportExtension.tsx
@@ -6,7 +6,7 @@ import { isValidAddress } from "@w3ux/utils";
 import type { ExtensionAccount } from "../ExtensionsProvider/types";
 import { HandleImportExtension } from "./types";
 import { getActiveAccountLocal, getInExternalAccounts } from "./utils";
-import { DEFAULT_SS58_PREFIX, defaultHandleImportExtension } from "./defaults";
+import { DEFAULT_SS58, defaultHandleImportExtension } from "./defaults";
 import { AnyFunction } from "../types";
 
 export const useImportExtension = () => {
@@ -25,7 +25,7 @@ export const useImportExtension = () => {
     }
 
     const keyring = new Keyring();
-    keyring.setSS58Format(DEFAULT_SS58_PREFIX);
+    keyring.setSS58Format(DEFAULT_SS58);
 
     // Remove accounts that do not contain correctly formatted addresses.
     newAccounts = newAccounts.filter(({ address }) => isValidAddress(address));

--- a/library/react-connect-kit/src/ExtensionAccountsProvider/useImportExtension.tsx
+++ b/library/react-connect-kit/src/ExtensionAccountsProvider/useImportExtension.tsx
@@ -4,9 +4,9 @@ SPDX-License-Identifier: GPL-3.0-only */
 import Keyring from "@polkadot/keyring";
 import { isValidAddress } from "@w3ux/utils";
 import type { ExtensionAccount } from "../ExtensionsProvider/types";
-import { HandleImportExtension, NetworkSS58 } from "./types";
+import { HandleImportExtension } from "./types";
 import { getActiveAccountLocal, getInExternalAccounts } from "./utils";
-import { defaultHandleImportExtension } from "./defaults";
+import { DEFAULT_SS58_PREFIX, defaultHandleImportExtension } from "./defaults";
 import { AnyFunction } from "../types";
 
 export const useImportExtension = () => {
@@ -18,19 +18,19 @@ export const useImportExtension = () => {
     currentAccounts: ExtensionAccount[],
     signer: AnyFunction,
     newAccounts: ExtensionAccount[],
-    { network, ss58 }: NetworkSS58
+    network: string
   ): HandleImportExtension => {
     if (!newAccounts.length) {
       return defaultHandleImportExtension;
     }
 
     const keyring = new Keyring();
-    keyring.setSS58Format(ss58);
+    keyring.setSS58Format(DEFAULT_SS58_PREFIX);
 
     // Remove accounts that do not contain correctly formatted addresses.
     newAccounts = newAccounts.filter(({ address }) => isValidAddress(address));
 
-    // Reformat addresses to ensure correct ss58 format.
+    // Reformat addresses to ensure default ss58 format.
     newAccounts.map((account) => {
       const { address } = keyring.addFromAddress(account.address);
       account.address = address;
@@ -48,7 +48,7 @@ export const useImportExtension = () => {
     // Check whether active account is present in forgotten accounts.
     const removedActiveAccount =
       removedAccounts.find(
-        ({ address }) => address === getActiveAccountLocal(network, ss58)
+        ({ address }) => address === getActiveAccountLocal(network)
       )?.address || null;
 
     // Remove accounts that have already been added to `currentAccounts` via another extension.

--- a/library/react-connect-kit/src/ExtensionAccountsProvider/utils.ts
+++ b/library/react-connect-kit/src/ExtensionAccountsProvider/utils.ts
@@ -5,7 +5,7 @@ import { localStorageOrDefault } from "@w3ux/utils";
 import Keyring from "@polkadot/keyring";
 import { ExtensionAccount } from "../ExtensionsProvider/types";
 import { AnyFunction, ExternalAccount } from "../types";
-import { DEFAULT_SS58_PREFIX } from "./defaults";
+import { DEFAULT_SS58 } from "./defaults";
 
 /*------------------------------------------------------------
    Active account utils.
@@ -14,7 +14,7 @@ import { DEFAULT_SS58_PREFIX } from "./defaults";
 // Gets local `active_acount` for a network.
 export const getActiveAccountLocal = (network: string) => {
   const keyring = new Keyring();
-  keyring.setSS58Format(DEFAULT_SS58_PREFIX);
+  keyring.setSS58Format(DEFAULT_SS58);
 
   let account = localStorageOrDefault(`${network}_active_account`, null);
   if (account !== null) {

--- a/library/react-connect-kit/src/ExtensionAccountsProvider/utils.ts
+++ b/library/react-connect-kit/src/ExtensionAccountsProvider/utils.ts
@@ -5,31 +5,32 @@ import { localStorageOrDefault } from "@w3ux/utils";
 import Keyring from "@polkadot/keyring";
 import { ExtensionAccount } from "../ExtensionsProvider/types";
 import { AnyFunction, ExternalAccount } from "../types";
-import { NetworkSS58 } from "./types";
+import { DEFAULT_SS58_PREFIX } from "./defaults";
 
 /*------------------------------------------------------------
    Active account utils.
  ------------------------------------------------------------*/
 
 // Gets local `active_acount` for a network.
-export const getActiveAccountLocal = (network: string, ss58: number) => {
+export const getActiveAccountLocal = (network: string) => {
   const keyring = new Keyring();
-  keyring.setSS58Format(ss58);
+  keyring.setSS58Format(DEFAULT_SS58_PREFIX);
+
   let account = localStorageOrDefault(`${network}_active_account`, null);
   if (account !== null) {
     account = keyring.addFromAddress(account).address;
   }
+
   return account;
 };
 
 // Checks if the local active account is the provided accounts.
 export const getActiveExtensionAccount = (
-  { network, ss58 }: NetworkSS58,
+  network: string,
   accounts: ExtensionAccount[]
 ) =>
-  accounts.find(
-    ({ address }) => address === getActiveAccountLocal(network, ss58)
-  ) ?? null;
+  accounts.find(({ address }) => address === getActiveAccountLocal(network)) ??
+  null;
 
 // Connects to active account, and calls an optional callback, if provided.
 export const connectActiveExtensionAccount = (
@@ -59,7 +60,7 @@ export const getInExternalAccounts = (
   );
 };
 
-// Gets local external accounts, formatting their addresses using active network ss58 format.
+// Gets local external accounts for a network.
 export const getLocalExternalAccounts = (network?: string) => {
   let localAccounts = localStorageOrDefault<ExternalAccount[]>(
     "external_accounts",


### PR DESCRIPTION
- `ExtensionAccountsProvider` no longer requires `ss58prefix`, and is instead passed through a getter function.
- Silently fail if Chainsafe Snap fails to initialise.