### PR TITLE
stop unwanted popup

### DIFF
--- a/library/react-connect-kit/package.json
+++ b/library/react-connect-kit/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@chainsafe/metamask-polkadot-adapter": "^0.6.0",
     "@polkadot/util": "^12.6.2",
-    "@polkagate/extension-dapp": "^0.46.12",
+    "@polkagate/extension-dapp": "^0.46.13",
     "@w3ux/extension-assets": "^0.2.3",
     "@w3ux/hooks": "^0.0.3",
     "@w3ux/utils": "^0.1.1"


### PR DESCRIPTION
This update will stop unwanted MetaMask popup, and will only show the PolkaGate Snap pop up when users click on Connect button.