### PR TITLE
feat: Introduce hybrid npm modules

### DIFF
--- a/builder/src/builders/extension-assets/index.ts
+++ b/builder/src/builders/extension-assets/index.ts
@@ -81,7 +81,8 @@ export const build = async () => {
     if (
       !(await generatePackageJson(
         libDirectory,
-        `${libDirectory}/${PACKAGE_OUTPUT}`
+        `${libDirectory}/${PACKAGE_OUTPUT}`,
+        "tsup"
       ))
     ) {
       throw `Failed to generate package.json file.`;

--- a/builder/src/builders/extension-assets/index.ts
+++ b/builder/src/builders/extension-assets/index.ts
@@ -60,7 +60,7 @@ export const build = async () => {
       `${libDirectory}/${TEMP_BUILD_OUTPUT}/`
     );
 
-    // Call tsup command to generate types in dist folder.
+    // Call tsup command to generate hybrid files and types in dist folder.
     try {
       await execPromisify(`cd ../library/${folder} && yarn build`);
     } catch (e) {
@@ -82,7 +82,7 @@ export const build = async () => {
       !(await generatePackageJson(
         libDirectory,
         `${libDirectory}/${PACKAGE_OUTPUT}`,
-        "tsup"
+        null
       ))
     ) {
       throw `Failed to generate package.json file.`;

--- a/builder/src/builders/hooks/index.ts
+++ b/builder/src/builders/hooks/index.ts
@@ -34,7 +34,8 @@ export const build = async () => {
     if (
       !(await generatePackageJson(
         libDirectory,
-        `${libDirectory}/${PACKAGE_OUTPUT}`
+        `${libDirectory}/${PACKAGE_OUTPUT}`,
+        "gulp"
       ))
     ) {
       throw `Failed to generate package.json file.`;

--- a/builder/src/builders/react-connect-kit/index.ts
+++ b/builder/src/builders/react-connect-kit/index.ts
@@ -35,7 +35,7 @@ export const build = async () => {
       !(await generatePackageJson(
         libDirectory,
         `${libDirectory}/${PACKAGE_OUTPUT}`,
-        "gulp"
+        "module"
       ))
     ) {
       throw `Failed to generate package.json file.`;

--- a/builder/src/builders/react-connect-kit/index.ts
+++ b/builder/src/builders/react-connect-kit/index.ts
@@ -34,7 +34,8 @@ export const build = async () => {
     if (
       !(await generatePackageJson(
         libDirectory,
-        `${libDirectory}/${PACKAGE_OUTPUT}`
+        `${libDirectory}/${PACKAGE_OUTPUT}`,
+        "gulp"
       ))
     ) {
       throw `Failed to generate package.json file.`;

--- a/builder/src/builders/react-odometer/index.ts
+++ b/builder/src/builders/react-odometer/index.ts
@@ -34,7 +34,8 @@ export const build = async () => {
     if (
       !(await generatePackageJson(
         libDirectory,
-        `${libDirectory}/${PACKAGE_OUTPUT}`
+        `${libDirectory}/${PACKAGE_OUTPUT}`,
+        "gulp"
       ))
     ) {
       throw `Failed to generate package.json file.`;

--- a/builder/src/builders/react-polkicon/index.ts
+++ b/builder/src/builders/react-polkicon/index.ts
@@ -34,7 +34,8 @@ export const build = async () => {
     if (
       !(await generatePackageJson(
         libDirectory,
-        `${libDirectory}/${PACKAGE_OUTPUT}`
+        `${libDirectory}/${PACKAGE_OUTPUT}`,
+        "gulp"
       ))
     ) {
       throw `Failed to generate package.json file.`;

--- a/builder/src/builders/types/index.ts
+++ b/builder/src/builders/types/index.ts
@@ -34,7 +34,8 @@ export const build = async () => {
     if (
       !(await generatePackageJson(
         libDirectory,
-        `${libDirectory}/${PACKAGE_OUTPUT}`
+        `${libDirectory}/${PACKAGE_OUTPUT}`,
+        "tsup"
       ))
     ) {
       throw `Failed to generate package.json file.`;

--- a/builder/src/builders/util.ts
+++ b/builder/src/builders/util.ts
@@ -94,7 +94,8 @@ export const getTemplate = async (name) => {
 // -----------------------------------------------------------
 export const generatePackageJson = async (
   inputDir: string,
-  outputDir: string
+  outputDir: string,
+  bundler: "gulp" | "tsup"
 ): Promise<boolean> => {
   try {
     // Read the original package.json.
@@ -108,20 +109,41 @@ export const generatePackageJson = async (
     const packageName = name.replace(/-source$/, ""); // Remove '-source' suffix.
 
     // Construct the minimal package.json object
-    const minimalPackageJson = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let minimalPackageJson: any = {
       name: packageName,
       version,
       license,
       dependencies,
-      main: "cjs/index.js",
-      module: "mjs/index.js",
-      exports: {
-        ".": {
-          import: "./mjs/index.js",
-          require: "./cjs/index.js",
-        },
-      },
     };
+
+    if (bundler === "gulp") {
+      minimalPackageJson = {
+        ...minimalPackageJson,
+        main: "cjs/index.js",
+        module: "mjs/index.js",
+        exports: {
+          ".": {
+            import: "./mjs/index.js",
+            require: "./cjs/index.js",
+          },
+        },
+      };
+    }
+
+    if (bundler === "tsup") {
+      minimalPackageJson = {
+        ...minimalPackageJson,
+        main: "index.cjs",
+        module: "index.js",
+        exports: {
+          ".": {
+            import: "./index.js",
+            require: "./index.cjs",
+          },
+        },
+      };
+    }
 
     if (dependencies) {
       minimalPackageJson["dependencies"] = dependencies;

--- a/builder/src/builders/util.ts
+++ b/builder/src/builders/util.ts
@@ -103,7 +103,7 @@ export const generatePackageJson = async (
     const parsedPackageJson = JSON.parse(originalPackageJson);
 
     // Extract only the specified fields.
-    const { name, version, license, types, dependencies, peerDependencies } =
+    const { name, version, license, dependencies, peerDependencies } =
       parsedPackageJson;
     const packageName = name.replace(/-source$/, ""); // Remove '-source' suffix.
 
@@ -112,7 +112,6 @@ export const generatePackageJson = async (
       name: packageName,
       version,
       license,
-      types,
       dependencies,
       main: "cjs/index.js",
       module: "mjs/index.js",

--- a/builder/src/builders/util.ts
+++ b/builder/src/builders/util.ts
@@ -103,7 +103,7 @@ export const generatePackageJson = async (
     const parsedPackageJson = JSON.parse(originalPackageJson);
 
     // Extract only the specified fields.
-    const { name, version, license, type, dependencies, peerDependencies } =
+    const { name, version, license, types, dependencies, peerDependencies } =
       parsedPackageJson;
     const packageName = name.replace(/-source$/, ""); // Remove '-source' suffix.
 
@@ -112,8 +112,16 @@ export const generatePackageJson = async (
       name: packageName,
       version,
       license,
-      type,
+      types,
       dependencies,
+      main: "cjs/index.js",
+      module: "mjs/index.js",
+      exports: {
+        ".": {
+          import: "./mjs/index.js",
+          require: "./cjs/index.js",
+        },
+      },
     };
 
     if (dependencies) {

--- a/builder/src/builders/util.ts
+++ b/builder/src/builders/util.ts
@@ -95,7 +95,7 @@ export const getTemplate = async (name) => {
 export const generatePackageJson = async (
   inputDir: string,
   outputDir: string,
-  bundler: "gulp" | "tsup"
+  bundler: "gulp" | "tsup" | null
 ): Promise<boolean> => {
   try {
     // Read the original package.json.

--- a/builder/src/builders/util.ts
+++ b/builder/src/builders/util.ts
@@ -95,7 +95,7 @@ export const getTemplate = async (name) => {
 export const generatePackageJson = async (
   inputDir: string,
   outputDir: string,
-  bundler: "gulp" | "tsup" | null
+  bundler: "gulp" | "tsup" | "module" | null
 ): Promise<boolean> => {
   try {
     // Read the original package.json.
@@ -116,6 +116,13 @@ export const generatePackageJson = async (
       license,
       dependencies,
     };
+
+    if (bundler === "module") {
+      minimalPackageJson = {
+        ...minimalPackageJson,
+        type: "module",
+      };
+    }
 
     if (bundler === "gulp") {
       minimalPackageJson = {

--- a/builder/src/builders/utils/index.ts
+++ b/builder/src/builders/utils/index.ts
@@ -34,7 +34,8 @@ export const build = async () => {
     if (
       !(await generatePackageJson(
         libDirectory,
-        `${libDirectory}/${PACKAGE_OUTPUT}`
+        `${libDirectory}/${PACKAGE_OUTPUT}`,
+        "tsup"
       ))
     ) {
       throw `Failed to generate package.json file.`;

--- a/builder/src/builders/validator-assets/index.ts
+++ b/builder/src/builders/validator-assets/index.ts
@@ -35,7 +35,7 @@ export const build = async () => {
       !(await generatePackageJson(
         libDirectory,
         `${libDirectory}/${PACKAGE_OUTPUT}`,
-        "tsup"
+        null
       ))
     ) {
       throw `Failed to generate package.json file.`;

--- a/builder/src/builders/validator-assets/index.ts
+++ b/builder/src/builders/validator-assets/index.ts
@@ -34,7 +34,8 @@ export const build = async () => {
     if (
       !(await generatePackageJson(
         libDirectory,
-        `${libDirectory}/${PACKAGE_OUTPUT}`
+        `${libDirectory}/${PACKAGE_OUTPUT}`,
+        "tsup"
       ))
     ) {
       throw `Failed to generate package.json file.`;

--- a/library/extension-assets/package.json
+++ b/library/extension-assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/extension-assets-source",
   "license": "GPL-3.0-only",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/extension-assets/package.json
+++ b/library/extension-assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/extension-assets-source",
   "license": "GPL-3.0-only",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/extension-assets/package.json
+++ b/library/extension-assets/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",
-    "build": "tsup .build/**/*{.ts,.tsx} --format esm --target es2022 --dts --no-splitting"
+    "build": "tsup .build/**/*{.ts,.tsx} --format esm,cjs --target es2022 --dts --no-splitting"
   },
   "peerDependencies": {
     "react": "^18"

--- a/library/hooks/gulpfile.js
+++ b/library/hooks/gulpfile.js
@@ -4,22 +4,40 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import gulp from "gulp";
 import ts from "gulp-typescript";
-import strip from "gulp-strip-comments";
 import sourcemaps from "gulp-sourcemaps";
 import merge from "merge-stream";
 
-const { src, dest, series } = gulp;
+const { dest, series } = gulp;
 
-const buildComponents = () => {
-  var tsProject = ts.createProject("tsconfig.json");
+// Buld CommonJS module.
+const buildCommonJs = () =>
+  doBuild(
+    ts.createProject("tsconfig.json", {
+      module: "commonjs",
+      target: "es2015",
+      removeComments: true,
+    }),
+    "cjs"
+  );
+
+// Build ES module.
+const buildEsm = () =>
+  doBuild(
+    ts.createProject("tsconfig.json", {
+      module: "esnext",
+      target: "esnext",
+      removeComments: true,
+    }),
+    "mjs"
+  );
+
+// Build package with provided Typescript project.
+const doBuild = (tsProject, outDir) => {
   var tsResult = tsProject.src().pipe(sourcemaps.init()).pipe(tsProject());
 
   return merge(tsResult, tsResult.js)
     .pipe(sourcemaps.write("."))
-    .pipe(dest("dist"));
+    .pipe(dest(`dist/${outDir}`));
 };
 
-const stripComments = () =>
-  src("dist/**/*.js").pipe(strip()).pipe(dest("dist"));
-
-export default series(buildComponents, stripComments);
+export default series(buildCommonJs, buildEsm);

--- a/library/hooks/package.json
+++ b/library/hooks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/hooks-source",
   "license": "GPL-3.0-only",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/react-connect-kit/gulpfile.js
+++ b/library/react-connect-kit/gulpfile.js
@@ -4,22 +4,40 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import gulp from "gulp";
 import ts from "gulp-typescript";
-import strip from "gulp-strip-comments";
 import sourcemaps from "gulp-sourcemaps";
 import merge from "merge-stream";
 
-const { src, dest, series } = gulp;
+const { dest, series } = gulp;
 
-const buildComponents = () => {
-  var tsProject = ts.createProject("tsconfig.json");
+// Buld CommonJS module.
+const buildCommonJs = () =>
+  doBuild(
+    ts.createProject("tsconfig.json", {
+      module: "commonjs",
+      target: "es2015",
+      removeComments: true,
+    }),
+    "cjs"
+  );
+
+// Build ES module.
+const buildEsm = () =>
+  doBuild(
+    ts.createProject("tsconfig.json", {
+      module: "esnext",
+      target: "esnext",
+      removeComments: true,
+    }),
+    "mjs"
+  );
+
+// Build package with provided Typescript project.
+const doBuild = (tsProject, outDir) => {
   var tsResult = tsProject.src().pipe(sourcemaps.init()).pipe(tsProject());
 
   return merge(tsResult, tsResult.js)
     .pipe(sourcemaps.write("."))
-    .pipe(dest("dist"));
+    .pipe(dest(`dist/${outDir}`));
 };
 
-const stripComments = () =>
-  src("dist/**/*.js").pipe(strip()).pipe(dest("dist"));
-
-export default series(buildComponents, stripComments);
+export default series(buildCommonJs, buildEsm);

--- a/library/react-connect-kit/gulpfile.js
+++ b/library/react-connect-kit/gulpfile.js
@@ -9,17 +9,6 @@ import merge from "merge-stream";
 
 const { dest, series } = gulp;
 
-// Buld CommonJS module.
-const buildCommonJs = () =>
-  doBuild(
-    ts.createProject("tsconfig.json", {
-      module: "commonjs",
-      target: "es2015",
-      removeComments: true,
-    }),
-    "cjs"
-  );
-
 // Build ES module.
 const buildEsm = () =>
   doBuild(
@@ -28,7 +17,7 @@ const buildEsm = () =>
       target: "esnext",
       removeComments: true,
     }),
-    "mjs"
+    "."
   );
 
 // Build package with provided Typescript project.
@@ -40,4 +29,4 @@ const doBuild = (tsProject, outDir) => {
     .pipe(dest(`dist/${outDir}`));
 };
 
-export default series(buildCommonJs, buildEsm);
+export default series(buildEsm);

--- a/library/react-connect-kit/package.json
+++ b/library/react-connect-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/react-connect-kit-source",
   "license": "GPL-3.0-only",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",
@@ -12,13 +12,13 @@
     "@polkadot/util": "^12.6.2",
     "@polkagate/extension-dapp": "^0.46.13",
     "@w3ux/extension-assets": "^0.3.0",
-    "@w3ux/hooks": "^1.0.0",
+    "@w3ux/hooks": "^1.1.0",
     "@w3ux/utils": "^0.4.0"
   },
   "devDependencies": {
     "@chainsafe/metamask-polkadot-types": "^0.7.0",
     "@types/react": "^18",
-    "@w3ux/types": "^0.1.0",
+    "@w3ux/types": "^0.2.0",
     "gulp": "^5.0.0",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-strip-comments": "^2.6.0",

--- a/library/react-connect-kit/package.json
+++ b/library/react-connect-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/react-connect-kit-source",
   "license": "GPL-3.0-only",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/react-connect-kit/package.json
+++ b/library/react-connect-kit/package.json
@@ -11,9 +11,9 @@
     "@chainsafe/metamask-polkadot-adapter": "^0.6.0",
     "@polkadot/util": "^12.6.2",
     "@polkagate/extension-dapp": "^0.46.13",
-    "@w3ux/extension-assets": "^0.2.6",
+    "@w3ux/extension-assets": "^0.3.0",
     "@w3ux/hooks": "^1.0.0",
-    "@w3ux/utils": "^0.3.0"
+    "@w3ux/utils": "^0.4.0"
   },
   "devDependencies": {
     "@chainsafe/metamask-polkadot-types": "^0.7.0",

--- a/library/react-connect-kit/package.json
+++ b/library/react-connect-kit/package.json
@@ -11,7 +11,7 @@
     "@chainsafe/metamask-polkadot-adapter": "^0.6.0",
     "@polkadot/util": "^12.6.2",
     "@polkagate/extension-dapp": "^0.46.13",
-    "@w3ux/extension-assets": "^0.3.0",
+    "@w3ux/extension-assets": "^0.3.1",
     "@w3ux/hooks": "^1.1.0",
     "@w3ux/utils": "^0.4.0"
   },

--- a/library/react-odometer/gulpfile.js
+++ b/library/react-odometer/gulpfile.js
@@ -4,31 +4,40 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import gulp from "gulp";
 import ts from "gulp-typescript";
-import strip from "gulp-strip-comments";
 import sourcemaps from "gulp-sourcemaps";
 import merge from "merge-stream";
-import * as sass from "sass";
-import sassFrom from "gulp-sass";
 
-const gulpSass = sassFrom(sass);
+const { dest, series } = gulp;
 
-const { src, dest, series } = gulp;
+// Buld CommonJS module.
+const buildCommonJs = () =>
+  doBuild(
+    ts.createProject("tsconfig.json", {
+      module: "commonjs",
+      target: "es2015",
+      removeComments: true,
+    }),
+    "cjs"
+  );
 
-const buildComponents = () => {
-  var tsProject = ts.createProject("tsconfig.json");
+// Build ES module.
+const buildEsm = () =>
+  doBuild(
+    ts.createProject("tsconfig.json", {
+      module: "esnext",
+      target: "esnext",
+      removeComments: true,
+    }),
+    "mjs"
+  );
+
+// Build package with provided Typescript project.
+const doBuild = (tsProject, outDir) => {
   var tsResult = tsProject.src().pipe(sourcemaps.init()).pipe(tsProject());
 
   return merge(tsResult, tsResult.js)
     .pipe(sourcemaps.write("."))
-    .pipe(dest("dist"));
+    .pipe(dest(`dist/${outDir}`));
 };
 
-const buildSass = () =>
-  src("./src/**/*.css")
-    .pipe(gulpSass({ outputStyle: "compressed" }))
-    .pipe(dest("dist"));
-
-const stripComments = () =>
-  src("dist/**/*.js").pipe(strip()).pipe(dest("dist"));
-
-export default series(buildSass, buildComponents, stripComments);
+export default series(buildCommonJs, buildEsm);

--- a/library/react-odometer/gulpfile.js
+++ b/library/react-odometer/gulpfile.js
@@ -6,8 +6,11 @@ import gulp from "gulp";
 import ts from "gulp-typescript";
 import sourcemaps from "gulp-sourcemaps";
 import merge from "merge-stream";
+import * as sass from "sass";
+import sassFrom from "gulp-sass";
 
-const { dest, series } = gulp;
+const gulpSass = sassFrom(sass);
+const { src, dest, series } = gulp;
 
 // Buld CommonJS module.
 const buildCommonJs = () =>
@@ -31,6 +34,18 @@ const buildEsm = () =>
     "mjs"
   );
 
+// Build CSS CommonJS.
+const buildSassCommonJs = () =>
+  src("./src/**/*.css")
+    .pipe(gulpSass({ outputStyle: "compressed" }))
+    .pipe(dest("dist/cjs"));
+
+// Build CSS ES module.
+const buildSassEsm = () =>
+  src("./src/**/*.css")
+    .pipe(gulpSass({ outputStyle: "compressed" }))
+    .pipe(dest("dist/mjs"));
+
 // Build package with provided Typescript project.
 const doBuild = (tsProject, outDir) => {
   var tsResult = tsProject.src().pipe(sourcemaps.init()).pipe(tsProject());
@@ -40,4 +55,4 @@ const doBuild = (tsProject, outDir) => {
     .pipe(dest(`dist/${outDir}`));
 };
 
-export default series(buildCommonJs, buildEsm);
+export default series(buildCommonJs, buildEsm, buildSassCommonJs, buildSassEsm);

--- a/library/react-odometer/package.json
+++ b/library/react-odometer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/react-odometer-source",
   "license": "GPL-3.0-only",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/react-polkicon/gulpfile.js
+++ b/library/react-polkicon/gulpfile.js
@@ -4,22 +4,40 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import gulp from "gulp";
 import ts from "gulp-typescript";
-import strip from "gulp-strip-comments";
 import sourcemaps from "gulp-sourcemaps";
 import merge from "merge-stream";
 
-const { src, dest, series } = gulp;
+const { dest, series } = gulp;
 
-const buildComponents = () => {
-  var tsProject = ts.createProject("tsconfig.json");
+// Buld CommonJS module.
+const buildCommonJs = () =>
+  doBuild(
+    ts.createProject("tsconfig.json", {
+      module: "commonjs",
+      target: "es2015",
+      removeComments: true,
+    }),
+    "cjs"
+  );
+
+// Build ES module.
+const buildEsm = () =>
+  doBuild(
+    ts.createProject("tsconfig.json", {
+      module: "esnext",
+      target: "esnext",
+      removeComments: true,
+    }),
+    "mjs"
+  );
+
+// Build package with provided Typescript project.
+const doBuild = (tsProject, outDir) => {
   var tsResult = tsProject.src().pipe(sourcemaps.init()).pipe(tsProject());
 
   return merge(tsResult, tsResult.js)
     .pipe(sourcemaps.write("."))
-    .pipe(dest("dist"));
+    .pipe(dest(`dist/${outDir}`));
 };
 
-const stripComments = () =>
-  src("dist/**/*.js").pipe(strip()).pipe(dest("dist"));
-
-export default series(buildComponents, stripComments);
+export default series(buildCommonJs, buildEsm);

--- a/library/react-polkicon/package.json
+++ b/library/react-polkicon/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@w3ux/react-polkicon-source",
   "license": "GPL-3.0-only",
-  "version": "1.1.1",
+  "version": "1.2.0-alpha.8",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",
-    "build": "gulp --silent"
+    "build": "gulp"
   },
   "dependencies": {
     "@polkadot/util": "^12.6.2",

--- a/library/react-polkicon/package.json
+++ b/library/react-polkicon/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@polkadot/util": "^12.6.2",
-    "@w3ux/utils": "^0.3.0",
+    "@w3ux/utils": "^0.4.0",
     "framer-motion": "^11.2.10"
   },
   "devDependencies": {

--- a/library/react-polkicon/package.json
+++ b/library/react-polkicon/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",
-    "build": "gulp"
+    "build": "gulp --silent"
   },
   "dependencies": {
     "@polkadot/util": "^12.6.2",

--- a/library/react-polkicon/package.json
+++ b/library/react-polkicon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/react-polkicon-source",
   "license": "GPL-3.0-only",
-  "version": "1.2.0-alpha.8",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/types/package.json
+++ b/library/types/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",
-    "build": "tsup src/**/* --format esm --target es2022 --dts --no-splitting"
+    "build": "tsup src/**/* --format esm,cjs --target es2022 --dts --no-splitting"
   },
   "devDependencies": {
     "@types/react": "^18",

--- a/library/types/package.json
+++ b/library/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/types-source",
   "license": "GPL-3.0-only",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/utils/package.json
+++ b/library/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/utils-source",
   "license": "GPL-3.0-only",
-  "version": "0.4.0-alpha.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/utils/package.json
+++ b/library/utils/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@w3ux/utils-source",
   "license": "GPL-3.0-only",
-  "version": "0.3.0",
+  "version": "0.4.0-alpha.0",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",
     "test": "vitest run",
-    "build": "tsup src/**/* --format esm --target es2022 --dts --no-splitting"
+    "build": "tsup src/**/* --format esm,cjs --target es2022 --dts --no-splitting"
   },
   "dependencies": {
     "@polkadot/keyring": "^12.6.2",

--- a/library/validator-assets/package.json
+++ b/library/validator-assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/validator-assets-source",
   "license": "GPL-3.0-only",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/validator-assets/package.json
+++ b/library/validator-assets/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",
-    "build": "tsup src/**/*{.ts,.tsx} --format esm --target es2022 --dts --no-splitting"
+    "build": "tsup src/**/*{.ts,.tsx} --format esm,cjs --target es2022 --dts --no-splitting"
   },
   "peerDependencies": {
     "react": "^18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1652,12 +1652,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@w3ux/extension-assets@npm:^0.2.6":
-  version: 0.2.6
-  resolution: "@w3ux/extension-assets@npm:0.2.6"
+"@w3ux/extension-assets@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@w3ux/extension-assets@npm:0.3.0"
   peerDependencies:
     react: ^18
-  checksum: 10c0/e789249b579c8786669cbeb13e0835bd790a092b61964f7714ec758b6d8b211287e09b934b02890991ffa660ba8bc18626364f5d7bf111e42ae640bb48258691
+  checksum: 10c0/05673b0b6dcb5d38a06a7884e32fce331516b69835ae417d76403072f7aa1551d04418b5a22c8cf5ef867755c9f5d9c6f39f1e6d7595ddb7573e984f451f8c3e
   languageName: node
   linkType: hard
 
@@ -1695,10 +1695,10 @@ __metadata:
     "@polkadot/util": "npm:^12.6.2"
     "@polkagate/extension-dapp": "npm:^0.46.13"
     "@types/react": "npm:^18"
-    "@w3ux/extension-assets": "npm:^0.2.6"
+    "@w3ux/extension-assets": "npm:^0.3.0"
     "@w3ux/hooks": "npm:^1.0.0"
     "@w3ux/types": "npm:^0.1.0"
-    "@w3ux/utils": "npm:^0.3.0"
+    "@w3ux/utils": "npm:^0.4.0"
     gulp: "npm:^5.0.0"
     gulp-sourcemaps: "npm:^3.0.0"
     gulp-strip-comments: "npm:^2.6.0"
@@ -1732,7 +1732,7 @@ __metadata:
   dependencies:
     "@polkadot/util": "npm:^12.6.2"
     "@types/react": "npm:^18"
-    "@w3ux/utils": "npm:^0.3.0"
+    "@w3ux/utils": "npm:^0.4.0"
     framer-motion: "npm:^11.2.10"
     gulp: "npm:^5.0.0"
     gulp-sourcemaps: "npm:^3.0.0"
@@ -1775,14 +1775,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@w3ux/utils@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@w3ux/utils@npm:0.3.0"
+"@w3ux/utils@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@w3ux/utils@npm:0.4.0"
   dependencies:
     "@polkadot/keyring": "npm:^12.6.2"
     "@polkadot/util": "npm:^12.6.2"
     bignumber.js: "npm:^9.1.1"
-  checksum: 10c0/8e5b231d4d39c0c5fa88d81f2fdcdf7a8f5a4fd5e8047124c8953fe539bc120593d80801432837247911a0fcc6eb877867c545283d1bdb2b1a7103ebf24257cf
+  checksum: 10c0/4384bccedcd7bccdad928393ca419a7fabc685b735df68d48243d7f7e4663cc1101a9e81073a666549a843bc130952a016125092b9a138f321900f6909a13960
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1652,12 +1652,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@w3ux/extension-assets@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@w3ux/extension-assets@npm:0.3.0"
+"@w3ux/extension-assets@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@w3ux/extension-assets@npm:0.3.1"
   peerDependencies:
     react: ^18
-  checksum: 10c0/05673b0b6dcb5d38a06a7884e32fce331516b69835ae417d76403072f7aa1551d04418b5a22c8cf5ef867755c9f5d9c6f39f1e6d7595ddb7573e984f451f8c3e
+  checksum: 10c0/2fccfde2b3a0e30047ea88be9b066124d8915042a7bb1a2bc679f325143377b2671daee3b5798e72f19098b789670a27bb85a10b3d73f4e624b9cada8944f3ad
   languageName: node
   linkType: hard
 
@@ -1695,7 +1695,7 @@ __metadata:
     "@polkadot/util": "npm:^12.6.2"
     "@polkagate/extension-dapp": "npm:^0.46.13"
     "@types/react": "npm:^18"
-    "@w3ux/extension-assets": "npm:^0.3.0"
+    "@w3ux/extension-assets": "npm:^0.3.1"
     "@w3ux/hooks": "npm:^1.1.0"
     "@w3ux/types": "npm:^0.2.0"
     "@w3ux/utils": "npm:^0.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,12 +1677,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@w3ux/hooks@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@w3ux/hooks@npm:1.0.0"
+"@w3ux/hooks@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@w3ux/hooks@npm:1.1.0"
   peerDependencies:
     react: ^18
-  checksum: 10c0/f92ace1fcb0364f0479f22f2af2f36759b630b815911c6c15646e4ac5840c3393829becaf9b6f9ec006560f07cdbfec2c4166baf88ab10360af7132fa92c63d2
+  checksum: 10c0/7889411294f9b33c2f43bdf7ac174e483ebfc6f415a866ed3ed4f31f8d0196704248f04d20915a0168412bff64d3a14439d0a97fa96cb07c6ac7b8985bcdf7af
   languageName: node
   linkType: hard
 
@@ -1696,8 +1696,8 @@ __metadata:
     "@polkagate/extension-dapp": "npm:^0.46.13"
     "@types/react": "npm:^18"
     "@w3ux/extension-assets": "npm:^0.3.0"
-    "@w3ux/hooks": "npm:^1.0.0"
-    "@w3ux/types": "npm:^0.1.0"
+    "@w3ux/hooks": "npm:^1.1.0"
+    "@w3ux/types": "npm:^0.2.0"
     "@w3ux/utils": "npm:^0.4.0"
     gulp: "npm:^5.0.0"
     gulp-sourcemaps: "npm:^3.0.0"
@@ -1757,6 +1757,13 @@ __metadata:
   version: 0.1.0
   resolution: "@w3ux/types@npm:0.1.0"
   checksum: 10c0/b7e55a4dea37298c5e34edf16cd049ef4b5e0a1f28bfe927f6615a31fc1c6e0810c509bbac20530256725f2438348979d7b750da9a03732d2e8214ab4ea9859c
+  languageName: node
+  linkType: hard
+
+"@w3ux/types@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@w3ux/types@npm:0.2.0"
+  checksum: 10c0/dae057b008f110f99da6c97c6f43849708234fbabeb5fa7370a3f9908513227f420ba48c6183b421ec9f8c758cd2c98e45a8a380efe6491012341bcc08b3063b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Lays the groundwork for hybrid npm modules.

`react-connect-kit` is still limited to ES6.
`extension-assets` and `validator-assets` include both formats but do not specify exports in `package.json`.