### PR TITLE
feat(refactor): Use `@polkadot` utils from `@w3ux/utils` to prevent multiple versions

### DIFF
--- a/builder/src/builders/util.ts
+++ b/builder/src/builders/util.ts
@@ -95,7 +95,14 @@ export const getTemplate = async (name) => {
 export const generatePackageJson = async (
   inputDir: string,
   outputDir: string,
-  bundler: "gulp" | "tsup" | "module" | null
+  bundler: "gulp" | "tsup" | "module" | null,
+  additionalExports: Record<
+    string,
+    {
+      import: string;
+      require: string;
+    }
+  > = {}
 ): Promise<boolean> => {
   try {
     // Read the original package.json.
@@ -134,6 +141,7 @@ export const generatePackageJson = async (
             import: "./mjs/index.js",
             require: "./cjs/index.js",
           },
+          ...additionalExports,
         },
       };
     }
@@ -148,6 +156,7 @@ export const generatePackageJson = async (
             import: "./index.js",
             require: "./index.cjs",
           },
+          ...additionalExports,
         },
       };
     }

--- a/builder/src/builders/utils/index.ts
+++ b/builder/src/builders/utils/index.ts
@@ -36,7 +36,7 @@ export const build = async () => {
         libDirectory,
         `${libDirectory}/${PACKAGE_OUTPUT}`,
         "tsup",
-        // Defining the additional entry points as `@polkadot/util` and `@polkadot/util-crypto`
+        // Defining the additional entry points as `polkadot/util` and `polkadot/util-crypto`
         // packages are re-exported.
         {
           "./util": {

--- a/builder/src/builders/utils/index.ts
+++ b/builder/src/builders/utils/index.ts
@@ -35,7 +35,19 @@ export const build = async () => {
       !(await generatePackageJson(
         libDirectory,
         `${libDirectory}/${PACKAGE_OUTPUT}`,
-        "tsup"
+        "tsup",
+        // Defining the additional entry points as `@polkadot/util` and `@polkadot/util-crypto`
+        // packages are re-exported.
+        {
+          "./util": {
+            import: "./util/index.js",
+            require: "./util/index.cjs",
+          },
+          "./util-crypto": {
+            import: "./util-crypto/index.js",
+            require: "./util-crypto/index.cjs",
+          },
+        }
       ))
     ) {
       throw `Failed to generate package.json file.`;

--- a/library/react-connect-kit/package.json
+++ b/library/react-connect-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/react-connect-kit-source",
   "license": "GPL-3.0-only",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",
@@ -9,11 +9,10 @@
   },
   "dependencies": {
     "@chainsafe/metamask-polkadot-adapter": "^0.6.0",
-    "@polkadot/util": "^13.1.1",
     "@polkagate/extension-dapp": "^0.46.13",
     "@w3ux/extension-assets": "^0.3.1",
     "@w3ux/hooks": "^1.1.0",
-    "@w3ux/utils": "^0.7.0"
+    "@w3ux/utils": "^0.9.0"
   },
   "devDependencies": {
     "@chainsafe/metamask-polkadot-types": "^0.7.0",

--- a/library/react-connect-kit/src/ExtensionAccountsProvider/snap.ts
+++ b/library/react-connect-kit/src/ExtensionAccountsProvider/snap.ts
@@ -15,9 +15,9 @@ import type {
   SignerPayloadRaw,
   SignerResult,
 } from "@polkadot/types/types";
-import type { HexString } from "@polkadot/util/types";
 import { SnapConfig } from "@chainsafe/metamask-polkadot-types";
 import { ExtensionAccount } from "../ExtensionsProvider/types";
+import { HexString } from "types";
 
 interface Web3Window extends InjectedWindow {
   ethereum: unknown;

--- a/library/react-connect-kit/src/ExtensionAccountsProvider/types.ts
+++ b/library/react-connect-kit/src/ExtensionAccountsProvider/types.ts
@@ -28,3 +28,5 @@ export interface HandleImportExtension {
     removedActiveAccount: MaybeAddress;
   };
 }
+
+export type HexString = `0x${string}`;

--- a/library/react-polkicon/package.json
+++ b/library/react-polkicon/package.json
@@ -1,15 +1,14 @@
 {
   "name": "@w3ux/react-polkicon-source",
   "license": "GPL-3.0-only",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",
     "build": "gulp --silent"
   },
   "dependencies": {
-    "@polkadot/util": "^12.6.2",
-    "@w3ux/utils": "^0.4.0",
+    "@w3ux/utils": "^0.9.0",
     "framer-motion": "^11.2.10"
   },
   "devDependencies": {

--- a/library/react-polkicon/src/utils.tsx
+++ b/library/react-polkicon/src/utils.tsx
@@ -1,7 +1,7 @@
 /* @license Copyright 2024 w3ux authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-import { decodeAddress, blake2AsU8a } from "@polkadot/util-crypto";
+import { decodeAddress, blake2AsU8a } from "@w3ux/utils/util-crypto";
 
 /*
   A generic identity icon, taken from

--- a/library/utils/package.json
+++ b/library/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/utils-source",
   "license": "GPL-3.0-only",
-  "version": "0.7.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/utils/src/util-crypto/index.ts
+++ b/library/utils/src/util-crypto/index.ts
@@ -1,0 +1,1 @@
+export * from "@polkadot/util-crypto";

--- a/library/utils/src/util/index.ts
+++ b/library/utils/src/util/index.ts
@@ -1,0 +1,1 @@
+export * from "@polkadot/util";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1691,13 +1691,12 @@ __metadata:
   dependencies:
     "@chainsafe/metamask-polkadot-adapter": "npm:^0.6.0"
     "@chainsafe/metamask-polkadot-types": "npm:^0.7.0"
-    "@polkadot/util": "npm:^13.1.1"
     "@polkagate/extension-dapp": "npm:^0.46.13"
     "@types/react": "npm:^18"
     "@w3ux/extension-assets": "npm:^0.3.1"
     "@w3ux/hooks": "npm:^1.1.0"
     "@w3ux/types": "npm:^0.2.0"
-    "@w3ux/utils": "npm:^0.7.0"
+    "@w3ux/utils": "npm:^0.9.0"
     gulp: "npm:^5.0.0"
     gulp-sourcemaps: "npm:^3.0.0"
     gulp-strip-comments: "npm:^2.6.0"
@@ -1729,9 +1728,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@w3ux/react-polkicon-source@workspace:library/react-polkicon"
   dependencies:
-    "@polkadot/util": "npm:^12.6.2"
     "@types/react": "npm:^18"
-    "@w3ux/utils": "npm:^0.4.0"
+    "@w3ux/utils": "npm:^0.9.0"
     framer-motion: "npm:^11.2.10"
     gulp: "npm:^5.0.0"
     gulp-sourcemaps: "npm:^3.0.0"
@@ -1781,25 +1779,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@w3ux/utils@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@w3ux/utils@npm:0.4.0"
-  dependencies:
-    "@polkadot/keyring": "npm:^12.6.2"
-    "@polkadot/util": "npm:^12.6.2"
-    bignumber.js: "npm:^9.1.1"
-  checksum: 10c0/4384bccedcd7bccdad928393ca419a7fabc685b735df68d48243d7f7e4663cc1101a9e81073a666549a843bc130952a016125092b9a138f321900f6909a13960
-  languageName: node
-  linkType: hard
-
-"@w3ux/utils@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@w3ux/utils@npm:0.7.0"
+"@w3ux/utils@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "@w3ux/utils@npm:0.9.0"
   dependencies:
     "@polkadot/util": "npm:^13.1.1"
     "@polkadot/util-crypto": "npm:^13.1.1"
     bignumber.js: "npm:^9.1.1"
-  checksum: 10c0/7b754a29716d575180501b6ac998afd7fb6b727e702af1b8f65be44503152573663b694df29fbe7e6bfec7da7c8bd43cf2047dde8820d61551abeeb778a1590a
+  checksum: 10c0/f2ffaabce464abfcd76608aafbbe7b342f69b618cac1b968be33db17860f4e55c5b7d6306183fc84a674ae191238950fe135e164cd80669d78c4b57320fe45ba
   languageName: node
   linkType: hard
 
@@ -3891,8 +3878,8 @@ __metadata:
   linkType: hard
 
 "framer-motion@npm:^11.2.10":
-  version: 11.9.0
-  resolution: "framer-motion@npm:11.9.0"
+  version: 11.10.0
+  resolution: "framer-motion@npm:11.10.0"
   dependencies:
     tslib: "npm:^2.4.0"
   peerDependencies:
@@ -3906,7 +3893,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 10c0/d1808a42c748d963be3b0a205a2187ee9efe599e2b0cbfd4196aee2c9587c02563572c925e7c39b9d7c06ad7a92678393725f7acc4ba1cd245db3af9441472e4
+  checksum: 10c0/06ead52252f30d180f0594999d877a882b6892c334053881b47decfad946b9ea68d84404cb91757cf707aac2c5f2d3d87197e0f43732a6a0eabfea4b75ecac13
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`@w3ux/utils` now re-exports `@polkadot/util` and `@polkadot/util-crypto` to-level exports to be used in the library and in external apps to prevent duplicated installs & multiple versions.