### PR TITLE
chore: substrate bindings for `AccountId` codec

### DIFF
--- a/library/utils/package.json
+++ b/library/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/utils-source",
   "license": "GPL-3.0-only",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",
@@ -9,8 +9,7 @@
     "build": "tsup src/**/* --format esm,cjs --target es2022 --dts --no-splitting"
   },
   "dependencies": {
-    "@polkadot/util": "^13.1.1",
-    "@polkadot/util-crypto": "^13.1.1",
+    "@polkadot-api/substrate-bindings": "^0.9.3",
     "bignumber.js": "^9.1.1"
   },
   "devDependencies": {

--- a/library/utils/src/base.ts
+++ b/library/utils/src/base.ts
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { BigNumber } from "bignumber.js";
 import { AnyFunction, AnyJson } from "@w3ux/types";
-import { decodeAddress, encodeAddress } from "@polkadot/util-crypto";
+import { AccountId } from "@polkadot-api/substrate-bindings";
 
 /**
  * @name camelize
@@ -200,11 +200,8 @@ export const formatAccountSs58 = (
   ss58Prefix: number
 ): string | null => {
   try {
-    // Decode the input address.
-    const decodedAddress = decodeAddress(address);
-    // Encode the address with the desired SS58 prefix.
-    const formattedAddress = encodeAddress(decodedAddress, ss58Prefix);
-    return formattedAddress;
+    const codec = AccountId(ss58Prefix);
+    return codec.dec(codec.enc(address));
   } catch (e) {
     return null;
   }

--- a/library/utils/src/unit.ts
+++ b/library/utils/src/unit.ts
@@ -1,13 +1,13 @@
 /* @license Copyright 2024 w3ux authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-import { decodeAddress } from "@polkadot/util-crypto";
-import { isHex, u8aToString, u8aUnwrapBytes } from "@polkadot/util";
+import { u8aToString, u8aUnwrapBytes } from "@polkadot/util";
 import { BigNumber } from "bignumber.js";
 import type { MutableRefObject, RefObject } from "react";
 import { AnyObject, EvalMessages } from "./types";
 import { ellipsisFn, rmCommas } from "./base";
 import { AnyJson } from "@w3ux/types";
+import { AccountId } from "@polkadot-api/substrate-bindings";
 
 /**
  * @name remToUnit
@@ -102,12 +102,8 @@ export const localStorageOrDefault = <T>(
  */
 export const isValidAddress = (address: string): boolean => {
   try {
-    // Check if the address is a valid hex string (which is a common public key format).
-    if (isHex(address)) {
-      return true;
-    }
-    // Try to decode the address; if it's not valid, this will throw an error.
-    decodeAddress(address);
+    const codec = AccountId();
+    codec.dec(codec.enc(address));
     return true;
   } catch (e) {
     return false;

--- a/library/utils/src/util-crypto/index.ts
+++ b/library/utils/src/util-crypto/index.ts
@@ -1,1 +1,0 @@
-export * from "@polkadot/util-crypto";

--- a/library/utils/src/util/index.ts
+++ b/library/utils/src/util/index.ts
@@ -1,1 +1,0 @@
-export * from "@polkadot/util";

--- a/yarn.lock
+++ b/yarn.lock
@@ -534,7 +534,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.5.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.3":
+"@noble/hashes@npm:1.5.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.3, @noble/hashes@npm:^1.4.0":
   version: 1.5.0
   resolution: "@noble/hashes@npm:1.5.0"
   checksum: 10c0/1b46539695fbfe4477c0822d90c881a04d4fa2921c08c552375b444a48cac9930cb1ee68de0a3c7859e676554d0f3771999716606dc4d8f826e414c11692cdd9
@@ -661,6 +661,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot-api/substrate-bindings@npm:^0.9.3":
+  version: 0.9.3
+  resolution: "@polkadot-api/substrate-bindings@npm:0.9.3"
+  dependencies:
+    "@noble/hashes": "npm:^1.4.0"
+    "@polkadot-api/utils": "npm:0.1.2"
+    "@scure/base": "npm:^1.1.7"
+    scale-ts: "npm:^1.6.1"
+  checksum: 10c0/d0b2e9adf3b28e7aaa1f52e26fd7b200defe1b83499450227289bff0ec784e7dab334e93dc8d989e10e31d6cbb3ac561afd50f1c25e54b9ddc2be02826ca43c2
+  languageName: node
+  linkType: hard
+
 "@polkadot-api/substrate-client@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0":
   version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
   resolution: "@polkadot-api/substrate-client@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
@@ -672,6 +684,13 @@ __metadata:
   version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
   resolution: "@polkadot-api/utils@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
   checksum: 10c0/63c36ac45d63a4f8718d1324be0290dadfbfbb387e440d5962de13200861400a6af09a5e96b73f985fd4c27d03c93927420c8145e49e1e822653a3c223dda645
+  languageName: node
+  linkType: hard
+
+"@polkadot-api/utils@npm:0.1.2":
+  version: 0.1.2
+  resolution: "@polkadot-api/utils@npm:0.1.2"
+  checksum: 10c0/530270141ab7a8d114aff68adabbc643a7b7f5abcfb974a5dac5044e1f5a459881f427e357a7eadfecf55847da5e48828be6dbcf502dd22e097c87546762a036
   languageName: node
   linkType: hard
 
@@ -1769,8 +1788,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@w3ux/utils-source@workspace:library/utils"
   dependencies:
-    "@polkadot/util": "npm:^13.1.1"
-    "@polkadot/util-crypto": "npm:^13.1.1"
+    "@polkadot-api/substrate-bindings": "npm:^0.9.3"
     "@types/react": "npm:^18"
     "@w3ux/types": "npm:^0.1.0"
     bignumber.js: "npm:^9.1.1"
@@ -6645,6 +6663,13 @@ __metadata:
   version: 1.6.0
   resolution: "scale-ts@npm:1.6.0"
   checksum: 10c0/ce4ea3559c6b6bdf2a62454aac83cc3151ae93d1a507ddb8e95e83ce1190085aed61c46901bd42d41d8f8ba58279d7e37057c68c2b674c2d39b8cf5d169e90dd
+  languageName: node
+  linkType: hard
+
+"scale-ts@npm:^1.6.1":
+  version: 1.6.1
+  resolution: "scale-ts@npm:1.6.1"
+  checksum: 10c0/bbcf476029095152189c5bd210922b43342e8bfb712bf56237de172d55b528e090419e80da67c627a8f706a228237346b82de527755d7f197bb4d822c6383dfd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Uses `@polkadot-api/substrate-bindings` for `AccountId` codec. Also discontinues upstream hosting of `@polkadot/util` and `@polkadot/util-crypto` as usage is wound down.