### PR TITLE
Unit to planck fix

### DIFF
--- a/library/utils/package.json
+++ b/library/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/utils-source",
   "license": "GPL-3.0-only",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/utils/src/unit.ts
+++ b/library/utils/src/unit.ts
@@ -66,21 +66,21 @@ export const unitToPlanck = (
   units: number
 ): bigint => {
   try {
-    // Parse `val` to a number if it's a string; if empty or invalid, default to "0"
+    // Convert `val` to a string; if empty or invalid, default to "0"
     const strVal = (typeof val === "string" ? val : val.toString()) || "0";
 
-    // Separate integer and fractional parts
+    // Split into integer and fractional parts
     const [integerPart, fractionalPart = ""] = strVal.split(".");
 
-    // Construct BigInt representation for integer part
+    // Process the integer part by converting to BigInt and scaling it to the given units
     let bigIntValue = BigInt(integerPart) * BigInt(10) ** BigInt(units);
 
-    // Add fractional part if it exists, scaled to appropriate power of 10
+    // Process the fractional part if it exists
     if (fractionalPart) {
-      const fractionalScale =
-        BigInt(10) ** BigInt(units - fractionalPart.length);
-      const fractionalValue = BigInt(fractionalPart.padEnd(units, "0")); // pad fractional part if needed
-      bigIntValue += fractionalValue / fractionalScale;
+      // Scale the fractional part by padding to the full number of decimal places
+      const paddedFractional = fractionalPart.padEnd(units, "0");
+      const fractionalValue = BigInt(paddedFractional);
+      bigIntValue += fractionalValue;
     }
 
     return bigIntValue;

--- a/library/utils/tests/unit.test.ts
+++ b/library/utils/tests/unit.test.ts
@@ -54,6 +54,16 @@ describe("unitToPlanck", () => {
     expect(result).toEqual(500000000n);
   });
 
+  test("should return valid planck value for a string input.", () => {
+    const result = fn.unitToPlanck("0.2", 10);
+    expect(result).toEqual(2000000000n);
+  });
+
+  test("should return valid planck value for a string input.", () => {
+    const result = fn.unitToPlanck("0.001", 10);
+    expect(result).toEqual(10000000n);
+  });
+
   test("should return valid planck value for a string input", () => {
     const result = fn.unitToPlanck("5", 6);
     expect(result).toEqual(5000000n);


### PR DESCRIPTION
Fixes an issue where `unitToPlanck` did not deal with decimals in the correct way. Added tests to validate function amendments.