### PR TITLE
feat(utils):unit fn enhancements + more tests

### DIFF
--- a/library/utils/package.json
+++ b/library/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/utils-source",
   "license": "GPL-3.0-only",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/utils/package.json
+++ b/library/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/utils-source",
   "license": "GPL-3.0-only",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/utils/src/unit.ts
+++ b/library/utils/src/unit.ts
@@ -4,7 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 import { u8aToString, u8aUnwrapBytes } from "@polkadot/util";
 import type { MutableRefObject, RefObject } from "react";
 import { AnyObject } from "./types";
-import { ellipsisFn } from "./base";
+import { ellipsisFn, rmCommas } from "./base";
 import { AnyJson } from "@w3ux/types";
 import { AccountId } from "@polkadot-api/substrate-bindings";
 
@@ -24,14 +24,16 @@ export const planckToUnit = (
   units: number
 ): string => {
   try {
-    // Ensure `units` is not negative.
-    units = Math.max(units, 0);
+    // Ensure `units` is a positive integer.
+    units = Math.max(Math.round(units), 0);
 
     // Convert `val` to BigInt based on its type
     const bigIntVal =
       typeof val === "bigint"
         ? val
-        : BigInt(typeof val === "number" ? Math.floor(val).toString() : val);
+        : BigInt(
+            typeof val === "number" ? Math.floor(val).toString() : rmCommas(val)
+          );
 
     const divisor = units === 0 ? 1n : BigInt(10) ** BigInt(units);
 
@@ -66,8 +68,12 @@ export const unitToPlanck = (
   units: number
 ): bigint => {
   try {
+    // Ensure `units` is a positive integer.
+    units = Math.max(Math.round(units), 0);
+
     // Convert `val` to a string; if empty or invalid, default to "0"
-    const strVal = (typeof val === "string" ? val : val.toString()) || "0";
+    const strVal =
+      (typeof val === "string" ? rmCommas(val) : val.toString()) || "0";
 
     // Split into integer and fractional parts
     const [integerPart, fractionalPart = ""] = strVal.split(".");

--- a/library/utils/tests/unit.test.ts
+++ b/library/utils/tests/unit.test.ts
@@ -26,9 +26,9 @@ describe("planckToUnit", () => {
     expect(result).toEqual("0.0000000010");
   });
 
-  test("values with commas are not supported and will result in a '0' result", () => {
+  test("commas are removed from strings and the conversion works.", () => {
     const result = fn.planckToUnit("10,000,000", 2);
-    expect(result).toEqual("0");
+    expect(result).toEqual("100000.00");
   });
 
   test("Invalid number values should result in a '0' result", () => {
@@ -37,13 +37,40 @@ describe("planckToUnit", () => {
   });
 
   test("should correctly convert a BigInt to a string", () => {
-    const result = fn.planckToUnit("10000000", 6);
+    const result = fn.planckToUnit(10000000n, 6);
     expect(result).toEqual("10.000000");
   });
 
   test("negative units are converted to 0 units", () => {
     const result = fn.planckToUnit(10000000n, -2);
     expect(result).toEqual("10000000");
+  });
+
+  test("negative units are converted to 0 units", () => {
+    const result = fn.planckToUnit(119324831n, -2);
+    expect(result).toEqual("119324831");
+  });
+
+  test("function handles very large unit values.", () => {
+    const result = fn.planckToUnit(10n, 100);
+    expect(result).toEqual(
+      "0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010"
+    );
+  });
+
+  test("function rounds down decimal unit values to an integer.", () => {
+    const result = fn.planckToUnit(10n, 0.1);
+    expect(result).toEqual("10");
+  });
+
+  test("function rounds up decimal unit values to an integer.", () => {
+    const result = fn.planckToUnit(10n, 0.7);
+    expect(result).toEqual("1.0");
+  });
+
+  test("function rounds up decimal larger unit values to an integer.", () => {
+    const result = fn.planckToUnit(10n, 9.7);
+    expect(result).toEqual("0.0000000010");
   });
 });
 
@@ -94,9 +121,19 @@ describe("unitToPlanck", () => {
     expect(result).toEqual(42n);
   });
 
-  test("should correctly convert a string to 0n with negative units", () => {
+  test("should correctly return the same value if negative units are provided", () => {
     const result = fn.unitToPlanck("100000", -6);
-    expect(result).toEqual(0n);
+    expect(result).toEqual(100000n);
+  });
+
+  test("should correctly return the same value if negative units are provided", () => {
+    const result = fn.unitToPlanck("1012192100", -3);
+    expect(result).toEqual(1012192100n);
+  });
+
+  test("should correctly return the same value if negative units are provided", () => {
+    const result = fn.unitToPlanck("1,012,192,100", -3);
+    expect(result).toEqual(1012192100n);
   });
 
   test("should return 0 for an empty string", () => {
@@ -107,5 +144,22 @@ describe("unitToPlanck", () => {
   test("should return 0 for a non-numeric string", () => {
     const result = fn.unitToPlanck("invalid&#l-", 4);
     expect(result).toEqual(0n);
+  });
+
+  test("function rounds down decimal unit values to an integer.", () => {
+    const result = fn.unitToPlanck(1000000n, 5.2);
+    expect(result).toEqual(100000000000n);
+  });
+
+  test("function rounds up decimal unit values to an integer.", () => {
+    const result = fn.unitToPlanck(1234567789012n, 14.8);
+    expect(result).toEqual(1234567789012000000000000000n);
+  });
+
+  test("function handles very large unit values.", () => {
+    const result = fn.unitToPlanck(10n, 100);
+    expect(result).toEqual(
+      100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000n
+    );
   });
 });


### PR DESCRIPTION
- Allows number strings with commas to be pased into `unitToPlanck` and `planckToUnit`.
- Rounds `unit` parameter to an integer when decimal units are parsed in to these functions.
- More tests.

Note: `unitToPlanck` and `planckToUnit` do not throw errors, but rather work with the arguments they are given.

For developers who may want more granularity in behaviour by adding validation and error handling, we can provide more robust functions in the future. These are very much plug and play functions for quick start, and work will if developers understand their opinionation.