### PR TITLE
feat: add `fontSize` prop to `Polkicon`, div -> span

### DIFF
--- a/library/react-polkicon/package.json
+++ b/library/react-polkicon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/react-polkicon-source",
   "license": "GPL-3.0-only",
-  "version": "2.0.0",
+  "version": "2.0.1-alpha.0",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/react-polkicon/src/index.tsx
+++ b/library/react-polkicon/src/index.tsx
@@ -12,6 +12,7 @@ export const Polkicon = ({
   background,
   inactive,
   transform: propTransform,
+  fontSize,
 }: PolkiconProps) => {
   // The colors of the Polkicon and inner circles.
   const [colors, setColors] = useState<string[]>([]);
@@ -55,13 +56,15 @@ export const Polkicon = ({
 
   return (
     coords && (
-      <div
+      <span
+        className="polkicon"
         style={{
           display: "inline-block",
+          verticalAlign: "-0.125em",
           height: "1em",
           width: "auto",
-          verticalAlign: "-0.125em",
           transform,
+          fontSize,
         }}
       >
         <svg
@@ -82,7 +85,7 @@ export const Polkicon = ({
             )
             .map(renderCircle)}
         </svg>
-      </div>
+      </span>
     )
   );
 };

--- a/library/react-polkicon/src/types.ts
+++ b/library/react-polkicon/src/types.ts
@@ -23,6 +23,7 @@ export interface PolkiconProps {
   background?: string;
   inactive?: boolean;
   transform?: TransformProp;
+  fontSize?: number | string;
 }
 
 export type TransformProp =


### PR DESCRIPTION
Adds `fontSize` to `Polkicon`, and changed its outer element to a `span`. Also assigns the `polkicon` className.