### PR TITLE
feat: add `rmDecimals` to utils, apply to `planckToUnit`

### DIFF
--- a/library/utils/package.json
+++ b/library/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@w3ux/utils-source",
   "license": "GPL-3.0-only",
-  "version": "1.1.1-beta.9",
+  "version": "1.1.1-beta.11",
   "type": "module",
   "scripts": {
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",

--- a/library/utils/src/base.ts
+++ b/library/utils/src/base.ts
@@ -159,7 +159,7 @@ export const pageFromUri = (pathname: string, fallback: string) => {
 export const rmCommas = (val: string): string => val.replace(/,/g, "");
 
 /**
- * @name rmCommas
+ * @name rmDecimals
  * @summary Removes the decimal point and decimals from a string.
  */
 export const rmDecimals = (str) => str.split(".")[0];

--- a/library/utils/src/base.ts
+++ b/library/utils/src/base.ts
@@ -159,6 +159,12 @@ export const pageFromUri = (pathname: string, fallback: string) => {
 export const rmCommas = (val: string): string => val.replace(/,/g, "");
 
 /**
+ * @name rmCommas
+ * @summary Removes the decimal point and decimals from a string.
+ */
+export const rmDecimals = (str) => str.split(".")[0];
+
+/**
  * @name shuffle
  * @summary Shuffle a set of objects.
  */

--- a/library/utils/src/unit.ts
+++ b/library/utils/src/unit.ts
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import type { MutableRefObject, RefObject } from "react";
 import { AnyObject } from "./types";
-import { rmCommas } from "./base";
+import { rmCommas, rmDecimals } from "./base";
 import { AnyJson } from "@w3ux/types";
 import { AccountId } from "@polkadot-api/substrate-bindings";
 
@@ -31,7 +31,9 @@ export const planckToUnit = (
       typeof val === "bigint"
         ? val
         : BigInt(
-            typeof val === "number" ? Math.floor(val).toString() : rmCommas(val)
+            typeof val === "number"
+              ? Math.floor(val).toString()
+              : rmDecimals(rmCommas(val))
           );
 
     const divisor = units === 0 ? 1n : BigInt(10) ** BigInt(units);

--- a/library/utils/tests/base.test.ts
+++ b/library/utils/tests/base.test.ts
@@ -113,6 +113,39 @@ describe("Tests suite - rmCommas Function", () => {
   });
 });
 
+describe("rmDecimals", () => {
+  test("should remove decimals from a string with a decimal point", () => {
+    expect(fn.rmDecimals("123.45")).toBe("123");
+    expect(fn.rmDecimals("45.6789")).toBe("45");
+  });
+
+  test("should return the original string if no decimal point exists", () => {
+    expect(fn.rmDecimals("678")).toBe("678");
+    expect(fn.rmDecimals("123")).toBe("123");
+  });
+
+  test("should handle empty strings", () => {
+    expect(fn.rmDecimals("")).toBe("");
+  });
+
+  test("should handle strings with multiple decimal points by removing everything after the first", () => {
+    expect(fn.rmDecimals("123.45.67")).toBe("123");
+  });
+
+  test("should handle strings with only a decimal point", () => {
+    expect(fn.rmDecimals(".")).toBe("");
+  });
+
+  test("should handle strings that start with a decimal point", () => {
+    expect(fn.rmDecimals(".123")).toBe("");
+  });
+
+  test("should handle strings with non-numeric characters", () => {
+    expect(fn.rmDecimals("abc.123")).toBe("abc");
+    expect(fn.rmDecimals("test.")).toBe("test");
+  });
+});
+
 describe("Test suite - shuffle Function", () => {
   test("should shuffle an array of numbers", () => {
     const inputArray = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];


### PR DESCRIPTION
Adds logic to ensure that `planck` string values are integers and not floats.